### PR TITLE
feat: create a config class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /.composer
 /vendor
 
+# PHPUnit
+.phpunit.result.cache
+
 # Compiled output
 /dist
 /tmp
@@ -35,7 +38,7 @@ Thumbs.db
 # Helm chart
 frontend-*.tgz
 
-# configuration files 
+# configuration files
 /src/config.ini
 /src/config.ini.development
 /src/config.ini.staging

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ Thumbs.db
 
 # Helm chart
 frontend-*.tgz
+
+# configuration files 
+/src/config.ini
+/src/config.ini.development
+/src/config.ini.staging
+/src/config.ini.production

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,0 +1,1 @@
+{"version":1,"defects":{"ConfigTest::testThrowsExceptionOnInvalidConfigFile":7},"times":{"ConfigTest::testLoadsDefaultConfig":0.003,"ConfigTest::testLoadsEnvironmentSpecificConfig":0,"ConfigTest::testHandlesMissingConfigFile":0,"ConfigTest::testThrowsExceptionOnInvalidConfigFile":0.009}}

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-{"version":1,"defects":{"ConfigTest::testThrowsExceptionOnInvalidConfigFile":7},"times":{"ConfigTest::testLoadsDefaultConfig":0.003,"ConfigTest::testLoadsEnvironmentSpecificConfig":0,"ConfigTest::testHandlesMissingConfigFile":0,"ConfigTest::testThrowsExceptionOnInvalidConfigFile":0.009}}

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace NewsLadder\PublisherAPI;
+
+/**
+ * Library configuration class
+ */
+class Config {
+
+    /**
+     * @var array
+     */
+    private $defaults = 
+        [
+            "environment" => [
+                "scope" => "production" 
+            ],
+            "origins" => [
+                "api_url" => "https://api.news-ladder.com/v1/" 
+            ]
+        ];
+
+    /**
+     * @var array
+     */
+    private $settings = [];
+
+    // Constructor loads the .ini file and stores the configuration data
+    public function __construct($filePath = __DIR__ . '/config.ini')
+    {
+        $this->settings = $this->defaults;
+
+        if (file_exists($filePath)) {
+            // Load the .ini file and store it as a multidimensional array
+            $this->settings = array_merge($this->settings, parse_ini_file($filePath, true));
+        }
+
+        // Save the environment
+        $environment_value = $this->get("environment", "scope");
+        
+        if (file_exists($filePath . "." . $environment_value)) {
+            // Load the .ini file and store it as a multidimensional array
+            $environment = parse_ini_file($filePath . "." . $environment_value, true);
+            
+            $this->settings = array_merge($this->settings, $environment);
+        }
+        
+    }
+ 
+    // Method to access configuration values, with an optional section parameter
+    public function get($section, $key = null)
+    {
+        // If only a section is specified, return it as an array
+        if ($key === null) {
+            return $this->settings[$section] ?? null;
+        }
+
+        // Return the specific value within the section
+        $value = $this->settings[$section][$key] ?? null;
+
+        // Check if the value is a list (e.g., comma-separated) and convert it to an array
+        if (is_string($value) && strpos($value, ',') !== false) {
+            $value = array_map('trim', explode(',', $value)); // Convert list to array and remove whitespace
+        }
+
+        return $value;
+    }
+}

--- a/src/Origins.php
+++ b/src/Origins.php
@@ -1,6 +1,0 @@
-<?php
-
-namespace NewsLadder\PublisherAPI;
-
-class Origins {
-}

--- a/src/config.ini.template
+++ b/src/config.ini.template
@@ -1,0 +1,2 @@
+[environment]
+scope = "production|staging|development"

--- a/src/config.ini.template.scope
+++ b/src/config.ini.template.scope
@@ -1,0 +1,2 @@
+[origins]
+api_url = "https://api.news-ladder.com/v1/"

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use NewsLadder\PublisherAPI\Config;
+
+beforeEach(function () {
+    
+    $this->current_default_config_file_path = __DIR__ . '/../../src/config.ini';
+    $this->current_default_config_file_path_tmp = __DIR__ . '/../../src/config.ini.temp';
+    
+    if (file_exists($this->current_default_config_file_path)) {
+        if (!rename($this->current_default_config_file_path, $this->current_default_config_file_path_tmp)) {
+            throw new Exception("Failed to rename $this->current_default_config_file_path to $this->current_default_config_file_path_tmp");
+        }
+    }
+
+    // Create temporary directories and files for each test
+    $this->tempDir = sys_get_temp_dir() . '/config_tests';
+    if (!file_exists($this->tempDir)) {
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    // Default configuration file
+    $this->defaultConfigPath = $this->tempDir . '/cconfig.ini';
+    file_put_contents($this->defaultConfigPath, "[environment]\nscope = \"production\"");
+
+    // Environment-specific configuration file
+    $this->envConfigPath = $this->tempDir . '/myconfig.ini.production';
+    file_put_contents($this->envConfigPath, "[origins]\napi_url = \"https://api.news-ladder.com/v1/\"\n");
+});
+
+afterEach(function () {
+    $this->current_default_config_file_path = __DIR__ . '/../../src/config.ini';
+    $this->current_default_config_file_path_tmp = __DIR__ . '/../../src/config.ini.temp';
+    
+    if (file_exists($this->current_default_config_file_path_tmp)) {
+        if (!rename($this->current_default_config_file_path_tmp, $this->current_default_config_file_path)) {
+            throw new Exception("Failed to rename $this->current_default_config_file_path to $this->current_default_config_file_path_tmp");
+        }
+    }
+
+    // Clean up temporary files and directories after each test
+    if (file_exists($this->defaultConfigPath)) {
+        unlink($this->defaultConfigPath);
+    }
+    if (file_exists($this->envConfigPath)) {
+        unlink($this->envConfigPath);
+    }
+    if (file_exists($this->tempDir)) {
+        rmdir($this->tempDir);
+    }
+});
+
+test('loads default configuration values', function () {
+    // Delete the environment-specific config file to test default loading
+    unlink($this->envConfigPath);
+    
+    $config = new Config();
+
+    expect($config->get('environment', 'scope'))->toBe('production');
+    expect($config->get('origins', 'api_url'))->toBe('https://api.news-ladder.com/v1/');
+});
+
+test('overrides default configuration with environment-specific config', function () {
+    $config = new Config($this->defaultConfigPath);
+
+    expect($config->get('origins', 'api_url'))->toBe('https://api.news-ladder.com/v1/');
+});
+
+test('handles missing configuration file gracefully', function () {
+    unlink($this->defaultConfigPath);
+
+    $config = new Config($this->defaultConfigPath);
+
+    expect($config->get('environment', 'scope'))->toBe('production');
+    expect($config->get('origins', 'api_url'))->toBe('https://api.news-ladder.com/v1/');
+});


### PR DESCRIPTION
The class load a config file.
This config file can be in the default directory as config.ini. The config file can although be loaded as a path.

If a scope is set the config var will be overwritten. In the class are the default values.

Test with composer run tests.